### PR TITLE
generating files no matter what

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 ### Fixed
 
 * Ensuring lock file unlocks when closing the watcher
+* Actually generating folder structure on configure

--- a/commands/configure/index.js
+++ b/commands/configure/index.js
@@ -17,11 +17,13 @@ const {
 } = require('../../lib/utils');
 
 const DIRECTORIES_TO_GENERATE = [
-  'files'
+  'files',
+  'experience'
 ];
 
 const LOCAL_META_FILES = [
-  'files'
+  'files',
+  'experience'
 ];
 
 const getApplicationFunc = (api) => {
@@ -97,6 +99,8 @@ program
     if (!userConfig.apiToken) {
       return logError('Must run losant login before running losant configure.');
     }
+    await Promise.all(DIRECTORIES_TO_GENERATE.map((dir) => { return ensureDir(dir); }));
+    await Promise.all(LOCAL_META_FILES.map((type) => { return saveLocalMeta(type, {}); }));
     const api = await getApi({ apiToken: userConfig.apiToken });
     const getApplication = getApplicationFunc(api);
     let appInfo;
@@ -145,9 +149,6 @@ program
         if (downloadedFiles) {
           logResult('success', 'Downloaded all of files!', 'green');
         }
-      } else {
-        await Promise.all(DIRECTORIES_TO_GENERATE.map((dir) => { return ensureDir(dir); }));
-        await Promise.all(LOCAL_META_FILES.map((type) => { return saveLocalMeta(type, {}); }));
       }
     } catch (e) {
       console.error(e);

--- a/lib/on-death.js
+++ b/lib/on-death.js
@@ -31,7 +31,7 @@ const handleUncaught = (type) => {
   };
 };
 
-if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV === 'production') {
   process.on('exit', () => {
     unlockConfigSync();
   });


### PR DESCRIPTION
- only rollbar-ing on production
- now generating the directories experience/ files/ and their corresponding configuration files even when there is nothing to download. 