### PR TITLE
Fix for windows upload file to losant

### DIFF
--- a/lib/get-upload-params.js
+++ b/lib/get-upload-params.js
@@ -59,7 +59,7 @@ const fileParams = {
   },
   getPostData: (item, config) => {
     const pathParts = path.parse(item.file);
-    let parentDirectory = pathParts.dir.replace('files', '');
+    let parentDirectory = pathParts.dir.replace('files', '').split(path.sep).join(path.posix.sep);
     if (!parentDirectory) { parentDirectory = '/'; }
     return {
       applicationId: config.applicationId,


### PR DESCRIPTION
There is a bug where losant server expects a posix folder structure i.e. "/" instead of "\".
When a windows file is uploaded it will create one folder e.g. "scripts\js\test"